### PR TITLE
Remaining operations

### DIFF
--- a/internal/api/amd64/bindings.h
+++ b/internal/api/amd64/bindings.h
@@ -34,6 +34,7 @@ enum Op {
   Op_Div = 5,
   Op_Gt = 6,
   Op_Gte = 7,
+  Op_Rem = 8,
 };
 typedef int32_t Op;
 

--- a/internal/api/amd64/bindings.h
+++ b/internal/api/amd64/bindings.h
@@ -38,6 +38,8 @@ enum Op {
   Op_BitAnd = 9,
   Op_BitOr = 10,
   Op_BitXor = 11,
+  Op_Eq = 12,
+  Op_Ne = 13,
 };
 typedef int32_t Op;
 

--- a/internal/api/amd64/bindings.h
+++ b/internal/api/amd64/bindings.h
@@ -32,6 +32,8 @@ enum Op {
   Op_Lt = 3,
   Op_Lte = 4,
   Op_Div = 5,
+  Op_Gt = 6,
+  Op_Gte = 7,
 };
 typedef int32_t Op;
 

--- a/internal/api/amd64/bindings.h
+++ b/internal/api/amd64/bindings.h
@@ -42,6 +42,8 @@ enum Op {
   Op_Ne = 13,
   Op_Min = 14,
   Op_Max = 15,
+  Op_Shl = 16,
+  Op_Shr = 17,
 };
 typedef int32_t Op;
 

--- a/internal/api/amd64/bindings.h
+++ b/internal/api/amd64/bindings.h
@@ -35,6 +35,9 @@ enum Op {
   Op_Gt = 6,
   Op_Gte = 7,
   Op_Rem = 8,
+  Op_BitAnd = 9,
+  Op_BitOr = 10,
+  Op_BitXor = 11,
 };
 typedef int32_t Op;
 

--- a/internal/api/amd64/bindings.h
+++ b/internal/api/amd64/bindings.h
@@ -31,6 +31,7 @@ enum Op {
   Op_Mul = 2,
   Op_Lt = 3,
   Op_Lte = 4,
+  Op_Div = 5,
 };
 typedef int32_t Op;
 

--- a/internal/api/amd64/bindings.h
+++ b/internal/api/amd64/bindings.h
@@ -40,6 +40,8 @@ enum Op {
   Op_BitXor = 11,
   Op_Eq = 12,
   Op_Ne = 13,
+  Op_Min = 14,
+  Op_Max = 15,
 };
 typedef int32_t Op;
 

--- a/internal/api/amd64/lib.go
+++ b/internal/api/amd64/lib.go
@@ -44,6 +44,7 @@ const (
 	mul               = C.Op_Mul
 	lt                = C.Op_Lt
 	lte               = C.Op_Lte
+	// todo why is this here?
 )
 
 // Pointers

--- a/internal/api/tfheCipherText.go
+++ b/internal/api/tfheCipherText.go
@@ -196,4 +196,12 @@ func (ct *Ciphertext) Xor(rhs *Ciphertext) (*Ciphertext, error) {
 	return ct.performOperation(rhs, xor)
 }
 
+func (ct *Ciphertext) Eq(rhs *Ciphertext) (*Ciphertext, error) {
+	return ct.performOperation(rhs, eq)
+}
+
+func (ct *Ciphertext) Ne(rhs *Ciphertext) (*Ciphertext, error) {
+	return ct.performOperation(rhs, ne)
+}
+
 // todo add more ops

--- a/internal/api/tfheCipherText.go
+++ b/internal/api/tfheCipherText.go
@@ -180,4 +180,8 @@ func (ct *Ciphertext) Gte(rhs *Ciphertext) (*Ciphertext, error) {
 	return ct.performOperation(rhs, gte)
 }
 
+func (ct *Ciphertext) Rem(rhs *Ciphertext) (*Ciphertext, error) {
+	return ct.performOperation(rhs, rem)
+}
+
 // todo add more ops

--- a/internal/api/tfheCipherText.go
+++ b/internal/api/tfheCipherText.go
@@ -172,4 +172,12 @@ func (ct *Ciphertext) Div(rhs *Ciphertext) (*Ciphertext, error) {
 	return ct.performOperation(rhs, div)
 }
 
+func (ct *Ciphertext) Gt(rhs *Ciphertext) (*Ciphertext, error) {
+	return ct.performOperation(rhs, gt)
+}
+
+func (ct *Ciphertext) Gte(rhs *Ciphertext) (*Ciphertext, error) {
+	return ct.performOperation(rhs, gte)
+}
+
 // todo add more ops

--- a/internal/api/tfheCipherText.go
+++ b/internal/api/tfheCipherText.go
@@ -184,4 +184,16 @@ func (ct *Ciphertext) Rem(rhs *Ciphertext) (*Ciphertext, error) {
 	return ct.performOperation(rhs, rem)
 }
 
+func (ct *Ciphertext) And(rhs *Ciphertext) (*Ciphertext, error) {
+	return ct.performOperation(rhs, and)
+}
+
+func (ct *Ciphertext) Or(rhs *Ciphertext) (*Ciphertext, error) {
+	return ct.performOperation(rhs, or)
+}
+
+func (ct *Ciphertext) Xor(rhs *Ciphertext) (*Ciphertext, error) {
+	return ct.performOperation(rhs, xor)
+}
+
 // todo add more ops

--- a/internal/api/tfheCipherText.go
+++ b/internal/api/tfheCipherText.go
@@ -149,7 +149,7 @@ func (ct *Ciphertext) performOperation(rhs *Ciphertext, operation uint32) (*Ciph
 
 // Add performs ciphertext addition.
 func (ct *Ciphertext) Add(rhs *Ciphertext) (*Ciphertext, error) {
-    return ct.performOperation(rhs, add)
+	return ct.performOperation(rhs, add)
 }
 
 func (ct *Ciphertext) Sub(rhs *Ciphertext) (*Ciphertext, error) {
@@ -167,3 +167,9 @@ func (ct *Ciphertext) Lt(rhs *Ciphertext) (*Ciphertext, error) {
 func (ct *Ciphertext) Lte(rhs *Ciphertext) (*Ciphertext, error) {
 	return ct.performOperation(rhs, lte)
 }
+
+func (ct *Ciphertext) Div(rhs *Ciphertext) (*Ciphertext, error) {
+	return ct.performOperation(rhs, div)
+}
+
+// todo add more ops

--- a/internal/api/tfheCipherText.go
+++ b/internal/api/tfheCipherText.go
@@ -212,4 +212,12 @@ func (ct *Ciphertext) Max(rhs *Ciphertext) (*Ciphertext, error) {
 	return ct.performOperation(rhs, max)
 }
 
+func (ct *Ciphertext) Shl(rhs *Ciphertext) (*Ciphertext, error) {
+	return ct.performOperation(rhs, shl)
+}
+
+func (ct *Ciphertext) Shr(rhs *Ciphertext) (*Ciphertext, error) {
+	return ct.performOperation(rhs, shr)
+}
+
 // todo add more ops

--- a/internal/api/tfheCipherText.go
+++ b/internal/api/tfheCipherText.go
@@ -204,4 +204,12 @@ func (ct *Ciphertext) Ne(rhs *Ciphertext) (*Ciphertext, error) {
 	return ct.performOperation(rhs, ne)
 }
 
+func (ct *Ciphertext) Min(rhs *Ciphertext) (*Ciphertext, error) {
+	return ct.performOperation(rhs, min)
+}
+
+func (ct *Ciphertext) Max(rhs *Ciphertext) (*Ciphertext, error) {
+	return ct.performOperation(rhs, max)
+}
+
 // todo add more ops

--- a/internal/api/tfheCipherText_test.go
+++ b/internal/api/tfheCipherText_test.go
@@ -101,6 +101,20 @@ func TestCipherTextOperations(t *testing.T) {
 	}
 	remResultFunc := func(a, b *big.Int) *big.Int { return new(big.Int).Rem(a, b) }
 
+	andOp := func(a, b *api.Ciphertext) (*api.Ciphertext, error) {
+		return a.And(b)
+	}
+	andResultFunc := func(a, b *big.Int) *big.Int { return new(big.Int).And(a, b) }
+
+	orOp := func(a, b *api.Ciphertext) (*api.Ciphertext, error) {
+		return a.Or(b)
+	}
+	orResultFunc := func(a, b *big.Int) *big.Int { return new(big.Int).Or(a, b) }
+
+	xorOp := func(a, b *api.Ciphertext) (*api.Ciphertext, error) {
+		return a.Xor(b)
+	}
+	xorResultFunc := func(a, b *big.Int) *big.Int { return new(big.Int).Xor(a, b) }
 	// todo add more ops
 
 	testCases := []struct {
@@ -159,7 +173,19 @@ func TestCipherTextOperations(t *testing.T) {
 		// Remainder tests
 		{"RemUint8", big.NewInt(102), big.NewInt(20), api.Uint8, remOp, remResultFunc, nil},
 		{"RemUint16", big.NewInt(1_000), big.NewInt(2), api.Uint16, remOp, remResultFunc, nil},
-		{"RemUint32", big.NewInt(1_000_024), big.NewInt(500_013), api.Uint32, remOp, remResultFunc, nil},
+		{"RemUint32", big.NewInt(1_000_024), big.NewInt(500_025), api.Uint32, remOp, remResultFunc, nil},
+		// Bitwise And tests
+		{"AndUint8", big.NewInt(102), big.NewInt(20), api.Uint8, andOp, andResultFunc, nil},
+		{"AndUint16", big.NewInt(1_000), big.NewInt(2), api.Uint16, andOp, andResultFunc, nil},
+		{"AndUint32", big.NewInt(1_000_024), big.NewInt(500_025), api.Uint32, andOp, andResultFunc, nil},
+		// Bitwise Or tests
+		{"OrUint8", big.NewInt(102), big.NewInt(20), api.Uint8, orOp, orResultFunc, nil},
+		{"OrUint16", big.NewInt(1_000), big.NewInt(2), api.Uint16, orOp, orResultFunc, nil},
+		{"OrUint32", big.NewInt(1_000_024), big.NewInt(500_025), api.Uint32, orOp, orResultFunc, nil},
+		// Bitwise Xor tests
+		{"XorUint8", big.NewInt(102), big.NewInt(20), api.Uint8, xorOp, xorResultFunc, nil},
+		{"XorUint16", big.NewInt(1_000), big.NewInt(2), api.Uint16, xorOp, xorResultFunc, nil},
+		{"XorUint32", big.NewInt(1_000_024), big.NewInt(500_025), api.Uint32, xorOp, xorResultFunc, nil},
 	}
 
 	for _, tt := range testCases {

--- a/internal/api/tfheCipherText_test.go
+++ b/internal/api/tfheCipherText_test.go
@@ -71,11 +71,12 @@ func TestCipherTextOperations(t *testing.T) {
 		return big.NewInt(0)
 	}
 
-	//// Assuming div function returns a Ciphertext of the quotient.
-	//divOp := func(a, b *api.Ciphertext) (*api.Ciphertext, error) {
-	//	return a.Div(b) // Assuming there's a Div method on Ciphertext.
-	//}
-	//divResultFunc := func(a, b *big.Int) *big.Int { return new(big.Int).Div(a, b) }
+	divOp := func(a, b *api.Ciphertext) (*api.Ciphertext, error) {
+		return a.Div(b)
+	}
+	divResultFunc := func(a, b *big.Int) *big.Int { return new(big.Int).Div(a, b) }
+
+	// todo add more ops
 
 	testCases := []struct {
 		name     string
@@ -86,7 +87,6 @@ func TestCipherTextOperations(t *testing.T) {
 		resultFn func(a, b *big.Int) *big.Int
 		err      error
 	}{
-
 		{"AddUint8", big.NewInt(10), big.NewInt(20), api.Uint16, addOp,
 			addResultFunc, nil},
 		{"AddUint16", big.NewInt(10), big.NewInt(20), api.Uint16, addOp,
@@ -114,9 +114,11 @@ func TestCipherTextOperations(t *testing.T) {
 		{"LteUint16", big.NewInt(500), big.NewInt(500), api.Uint16, lteOp, lteResultFunc, nil},
 		{"LteUint32", big.NewInt(500_000), big.NewInt(500_000), api.Uint32, lteOp, lteResultFunc, nil},
 
-		// Division tests (assuming Div function exists on Ciphertext)
-		//{"DivUint8", big.NewInt(100), big.NewInt(20), api.Uint8, divOp, divResultFunc, nil},
-		//{"DivUint16", big.NewInt(1_000), big.NewInt(2), api.Uint16, divOp, divResultFunc, nil},
+		// Division tests
+		{"DivUint8", big.NewInt(100), big.NewInt(20), api.Uint8, divOp, divResultFunc, nil},
+		{"DivUint16", big.NewInt(1_000), big.NewInt(2), api.Uint16, divOp, divResultFunc, nil},
+
+		// todo add more tests
 	}
 
 	for _, tt := range testCases {
@@ -147,7 +149,6 @@ func TestCipherTextOperations(t *testing.T) {
 			if resDec.Cmp(expected) != 0 {
 				t.Fatalf("Result is not what we expected: %s vs %s", resDec, expected)
 			}
-
 		})
 	}
 }

--- a/internal/api/tfheCipherText_test.go
+++ b/internal/api/tfheCipherText_test.go
@@ -115,6 +115,26 @@ func TestCipherTextOperations(t *testing.T) {
 		return a.Xor(b)
 	}
 	xorResultFunc := func(a, b *big.Int) *big.Int { return new(big.Int).Xor(a, b) }
+
+	eqOp := func(a, b *api.Ciphertext) (*api.Ciphertext, error) {
+		return a.Eq(b)
+	}
+	eqResultFunc := func(a, b *big.Int) *big.Int {
+		if a.Cmp(b) == 0 {
+			return big.NewInt(1)
+		}
+		return big.NewInt(0)
+	}
+
+	neOp := func(a, b *api.Ciphertext) (*api.Ciphertext, error) {
+		return a.Ne(b)
+	}
+	neResultFunc := func(a, b *big.Int) *big.Int {
+		if a.Cmp(b) != 0 {
+			return big.NewInt(1)
+		}
+		return big.NewInt(0)
+	}
 	// todo add more ops
 
 	testCases := []struct {
@@ -186,6 +206,20 @@ func TestCipherTextOperations(t *testing.T) {
 		{"XorUint8", big.NewInt(102), big.NewInt(20), api.Uint8, xorOp, xorResultFunc, nil},
 		{"XorUint16", big.NewInt(1_000), big.NewInt(2), api.Uint16, xorOp, xorResultFunc, nil},
 		{"XorUint32", big.NewInt(1_000_024), big.NewInt(500_025), api.Uint32, xorOp, xorResultFunc, nil},
+		// Equality tests
+		{"EqUint8-true", big.NewInt(10), big.NewInt(10), api.Uint8, eqOp, eqResultFunc, nil},
+		{"EqUint8-false", big.NewInt(10), big.NewInt(11), api.Uint8, eqOp, eqResultFunc, nil},
+		{"EqUint16-true", big.NewInt(1_000), big.NewInt(1_000), api.Uint16, eqOp, eqResultFunc, nil},
+		{"EqUint16-false", big.NewInt(1_000), big.NewInt(999), api.Uint16, eqOp, eqResultFunc, nil},
+		{"EqUint32-true", big.NewInt(1_000_000), big.NewInt(1_000_000), api.Uint32, eqOp, eqResultFunc, nil},
+		{"EqUint32-false", big.NewInt(1_000_000), big.NewInt(1_000_001), api.Uint32, eqOp, eqResultFunc, nil},
+		// Inequality tests
+		{"NeUint8-true", big.NewInt(10), big.NewInt(10), api.Uint8, neOp, neResultFunc, nil},
+		{"NeUint8-false", big.NewInt(10), big.NewInt(11), api.Uint8, neOp, neResultFunc, nil},
+		{"NeUint16-true", big.NewInt(1_000), big.NewInt(1_000), api.Uint16, neOp, neResultFunc, nil},
+		{"NeUint16-false", big.NewInt(1_000), big.NewInt(999), api.Uint16, neOp, neResultFunc, nil},
+		{"NeUint32-true", big.NewInt(1_000_000), big.NewInt(1_000_000), api.Uint32, neOp, neResultFunc, nil},
+		{"NeUint32-false", big.NewInt(1_000_000), big.NewInt(1_000_001), api.Uint32, neOp, neResultFunc, nil},
 	}
 
 	for _, tt := range testCases {

--- a/internal/api/tfheCipherText_test.go
+++ b/internal/api/tfheCipherText_test.go
@@ -156,6 +156,16 @@ func TestCipherTextOperations(t *testing.T) {
 		return b
 	}
 
+	shlOp := func(a, b *api.Ciphertext) (*api.Ciphertext, error) {
+		return a.Shl(b)
+	}
+	shlResultFunc := func(a, b *big.Int) *big.Int { return a.Lsh(a, uint(b.Uint64())) }
+
+	shrOp := func(a, b *api.Ciphertext) (*api.Ciphertext, error) {
+		return a.Shr(b)
+	}
+	shrResultFunc := func(a, b *big.Int) *big.Int { return a.Rsh(a, uint(b.Uint64())) }
+
 	// todo add more ops
 
 	testCases := []struct {
@@ -255,6 +265,14 @@ func TestCipherTextOperations(t *testing.T) {
 		{"MaxUint16-rhs", big.NewInt(1_000), big.NewInt(999), api.Uint16, maxOp, maxResultFunc, nil},
 		{"MaxUint32-lhs", big.NewInt(2_000_000), big.NewInt(1_000_000), api.Uint32, maxOp, maxResultFunc, nil},
 		{"MaxUint32-rhs", big.NewInt(1_000_000), big.NewInt(900_001), api.Uint32, maxOp, maxResultFunc, nil},
+		// Shift left tests
+		{"ShlUint8", big.NewInt(102), big.NewInt(1), api.Uint8, shlOp, shlResultFunc, nil},
+		{"ShlUint16", big.NewInt(1_000), big.NewInt(2), api.Uint16, shlOp, shlResultFunc, nil},
+		{"ShlUint32", big.NewInt(1_000_024), big.NewInt(5), api.Uint32, shlOp, shlResultFunc, nil},
+		// Shift right tests
+		{"ShrUint8", big.NewInt(102), big.NewInt(1), api.Uint8, shrOp, shrResultFunc, nil},
+		{"ShrUint16", big.NewInt(1_000), big.NewInt(2), api.Uint16, shrOp, shrResultFunc, nil},
+		{"ShrUint32", big.NewInt(1_000_024), big.NewInt(5), api.Uint32, shrOp, shrResultFunc, nil},
 	}
 
 	for _, tt := range testCases {

--- a/internal/api/tfheCipherText_test.go
+++ b/internal/api/tfheCipherText_test.go
@@ -77,6 +77,25 @@ func TestCipherTextOperations(t *testing.T) {
 	divResultFunc := func(a, b *big.Int) *big.Int { return new(big.Int).Div(a, b) }
 
 	// todo add more ops
+	gtOp := func(a, b *api.Ciphertext) (*api.Ciphertext, error) {
+		return a.Gt(b)
+	}
+	gtResultFunc := func(a, b *big.Int) *big.Int {
+		if a.Cmp(b) > 0 {
+			return big.NewInt(1)
+		}
+		return big.NewInt(0)
+	}
+
+	gteOp := func(a, b *api.Ciphertext) (*api.Ciphertext, error) {
+		return a.Gte(b)
+	}
+	gteResultFunc := func(a, b *big.Int) *big.Int {
+		if a.Cmp(b) >= 0 {
+			return big.NewInt(1)
+		}
+		return big.NewInt(0)
+	}
 
 	testCases := []struct {
 		name     string
@@ -113,12 +132,23 @@ func TestCipherTextOperations(t *testing.T) {
 		{"LteUint8", big.NewInt(10), big.NewInt(10), api.Uint8, lteOp, lteResultFunc, nil},
 		{"LteUint16", big.NewInt(500), big.NewInt(500), api.Uint16, lteOp, lteResultFunc, nil},
 		{"LteUint32", big.NewInt(500_000), big.NewInt(500_000), api.Uint32, lteOp, lteResultFunc, nil},
-
 		// Division tests
 		{"DivUint8", big.NewInt(100), big.NewInt(20), api.Uint8, divOp, divResultFunc, nil},
 		{"DivUint16", big.NewInt(1_000), big.NewInt(2), api.Uint16, divOp, divResultFunc, nil},
-
-		// todo add more tests
+		// Greater Than tests
+		{"GtUint8-true", big.NewInt(10), big.NewInt(20), api.Uint8, gtOp, gtResultFunc, nil},
+		{"GtUint8-false", big.NewInt(10), big.NewInt(10), api.Uint8, gtOp, gtResultFunc, nil},
+		{"GtUint16-true", big.NewInt(1_000), big.NewInt(500), api.Uint16, gtOp, gtResultFunc, nil},
+		{"GtUint16-false", big.NewInt(1_000), big.NewInt(1000), api.Uint16, gtOp, gtResultFunc, nil},
+		{"GtUint32-true", big.NewInt(1_000_000), big.NewInt(999_999), api.Uint32, gtOp, gtResultFunc, nil},
+		{"GtUint32-false", big.NewInt(1_000_000), big.NewInt(1_000_001), api.Uint32, gtOp, gtResultFunc, nil},
+		// Greater Than or Equal tests
+		{"GteUint8-true", big.NewInt(10), big.NewInt(10), api.Uint8, gteOp, gteResultFunc, nil},
+		{"GteUint8-false", big.NewInt(10), big.NewInt(9), api.Uint8, gteOp, gteResultFunc, nil},
+		{"GteUint16-true", big.NewInt(1_000), big.NewInt(100), api.Uint16, gteOp, gteResultFunc, nil},
+		{"GteUint16-false", big.NewInt(1_000), big.NewInt(999), api.Uint16, gteOp, gteResultFunc, nil},
+		{"GteUint32-true", big.NewInt(1_000_000), big.NewInt(1_000_000), api.Uint32, gteOp, gteResultFunc, nil},
+		{"GteUint32-false", big.NewInt(1_000_000), big.NewInt(1_000_001), api.Uint32, gteOp, gteResultFunc, nil},
 	}
 
 	for _, tt := range testCases {

--- a/internal/api/tfheCipherText_test.go
+++ b/internal/api/tfheCipherText_test.go
@@ -135,6 +135,27 @@ func TestCipherTextOperations(t *testing.T) {
 		}
 		return big.NewInt(0)
 	}
+
+	minOp := func(a, b *api.Ciphertext) (*api.Ciphertext, error) {
+		return a.Min(b)
+	}
+	minResultFunc := func(a, b *big.Int) *big.Int {
+		if a.Cmp(b) <= 0 {
+			return a
+		}
+		return b
+	}
+
+	maxOp := func(a, b *api.Ciphertext) (*api.Ciphertext, error) {
+		return a.Max(b)
+	}
+	maxResultFunc := func(a, b *big.Int) *big.Int {
+		if a.Cmp(b) >= 0 {
+			return a
+		}
+		return b
+	}
+
 	// todo add more ops
 
 	testCases := []struct {
@@ -220,6 +241,20 @@ func TestCipherTextOperations(t *testing.T) {
 		{"NeUint16-false", big.NewInt(1_000), big.NewInt(999), api.Uint16, neOp, neResultFunc, nil},
 		{"NeUint32-true", big.NewInt(1_000_000), big.NewInt(1_000_000), api.Uint32, neOp, neResultFunc, nil},
 		{"NeUint32-false", big.NewInt(1_000_000), big.NewInt(1_000_001), api.Uint32, neOp, neResultFunc, nil},
+		// Minimum tests
+		{"MinUint8-lhs", big.NewInt(10), big.NewInt(11), api.Uint8, minOp, minResultFunc, nil},
+		{"MinUint8-rhs", big.NewInt(10), big.NewInt(9), api.Uint8, minOp, minResultFunc, nil},
+		{"MinUint16-lhs", big.NewInt(1_000), big.NewInt(2_000), api.Uint16, minOp, minResultFunc, nil},
+		{"MinUint16-rhs", big.NewInt(1_000), big.NewInt(999), api.Uint16, minOp, minResultFunc, nil},
+		{"MinUint32-lhs", big.NewInt(1_000_000), big.NewInt(2_000_000), api.Uint32, minOp, minResultFunc, nil},
+		{"MinUint32-rhs", big.NewInt(1_000_000), big.NewInt(900_999), api.Uint32, minOp, minResultFunc, nil},
+		// Maximum tests
+		{"MaxUint8-lhs", big.NewInt(11), big.NewInt(10), api.Uint8, maxOp, maxResultFunc, nil},
+		{"MaxUint8-rhs", big.NewInt(10), big.NewInt(11), api.Uint8, maxOp, maxResultFunc, nil},
+		{"MaxUint16-lhs", big.NewInt(2_000), big.NewInt(1_000), api.Uint16, maxOp, maxResultFunc, nil},
+		{"MaxUint16-rhs", big.NewInt(1_000), big.NewInt(999), api.Uint16, maxOp, maxResultFunc, nil},
+		{"MaxUint32-lhs", big.NewInt(2_000_000), big.NewInt(1_000_000), api.Uint32, maxOp, maxResultFunc, nil},
+		{"MaxUint32-rhs", big.NewInt(1_000_000), big.NewInt(900_001), api.Uint32, maxOp, maxResultFunc, nil},
 	}
 
 	for _, tt := range testCases {

--- a/internal/api/tfheCipherText_test.go
+++ b/internal/api/tfheCipherText_test.go
@@ -76,7 +76,6 @@ func TestCipherTextOperations(t *testing.T) {
 	}
 	divResultFunc := func(a, b *big.Int) *big.Int { return new(big.Int).Div(a, b) }
 
-	// todo add more ops
 	gtOp := func(a, b *api.Ciphertext) (*api.Ciphertext, error) {
 		return a.Gt(b)
 	}
@@ -96,6 +95,13 @@ func TestCipherTextOperations(t *testing.T) {
 		}
 		return big.NewInt(0)
 	}
+
+	remOp := func(a, b *api.Ciphertext) (*api.Ciphertext, error) {
+		return a.Rem(b)
+	}
+	remResultFunc := func(a, b *big.Int) *big.Int { return new(big.Int).Rem(a, b) }
+
+	// todo add more ops
 
 	testCases := []struct {
 		name     string
@@ -135,6 +141,7 @@ func TestCipherTextOperations(t *testing.T) {
 		// Division tests
 		{"DivUint8", big.NewInt(100), big.NewInt(20), api.Uint8, divOp, divResultFunc, nil},
 		{"DivUint16", big.NewInt(1_000), big.NewInt(2), api.Uint16, divOp, divResultFunc, nil},
+		{"DivUint32", big.NewInt(1_000_024), big.NewInt(500_012), api.Uint32, divOp, divResultFunc, nil},
 		// Greater Than tests
 		{"GtUint8-true", big.NewInt(10), big.NewInt(20), api.Uint8, gtOp, gtResultFunc, nil},
 		{"GtUint8-false", big.NewInt(10), big.NewInt(10), api.Uint8, gtOp, gtResultFunc, nil},
@@ -149,6 +156,10 @@ func TestCipherTextOperations(t *testing.T) {
 		{"GteUint16-false", big.NewInt(1_000), big.NewInt(999), api.Uint16, gteOp, gteResultFunc, nil},
 		{"GteUint32-true", big.NewInt(1_000_000), big.NewInt(1_000_000), api.Uint32, gteOp, gteResultFunc, nil},
 		{"GteUint32-false", big.NewInt(1_000_000), big.NewInt(1_000_001), api.Uint32, gteOp, gteResultFunc, nil},
+		// Remainder tests
+		{"RemUint8", big.NewInt(102), big.NewInt(20), api.Uint8, remOp, remResultFunc, nil},
+		{"RemUint16", big.NewInt(1_000), big.NewInt(2), api.Uint16, remOp, remResultFunc, nil},
+		{"RemUint32", big.NewInt(1_000_024), big.NewInt(500_013), api.Uint32, remOp, remResultFunc, nil},
 	}
 
 	for _, tt := range testCases {

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -31,6 +31,9 @@ const (
 	gt         = 6
 	gte        = 7
 	rem        = 8
+	and        = 9
+	or         = 10
+	xor        = 11
 	// todo add more ops
 )
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -30,6 +30,7 @@ const (
 	div        = 5
 	gt         = 6
 	gte        = 7
+	rem        = 8
 	// todo add more ops
 )
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -38,6 +38,8 @@ const (
 	ne         = 13
 	min        = 14
 	max        = 15
+	shl        = 16
+	shr        = 17
 	// todo add more ops
 )
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -34,6 +34,8 @@ const (
 	and        = 9
 	or         = 10
 	xor        = 11
+	eq         = 12
+	ne         = 13
 	// todo add more ops
 )
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -27,6 +27,8 @@ const (
 	mul        = 2
 	lt         = 3
 	lte        = 4
+	div        = 5
+	// todo add more ops
 )
 
 type UintType uint32
@@ -34,7 +36,6 @@ type UintType uint32
 const HashLength = 32
 
 type Hash [HashLength]byte
-
 
 func BytesToHash(b []byte) Hash {
 	var h Hash

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -28,6 +28,8 @@ const (
 	lt         = 3
 	lte        = 4
 	div        = 5
+	gt         = 6
+	gte        = 7
 	// todo add more ops
 )
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -36,6 +36,8 @@ const (
 	xor        = 11
 	eq         = 12
 	ne         = 13
+	min        = 14
+	max        = 15
 	// todo add more ops
 )
 

--- a/libtfhe-wrapper/src/api/ffi/api.rs
+++ b/libtfhe-wrapper/src/api/ffi/api.rs
@@ -25,6 +25,7 @@ pub enum Op {
     Div = 5,
     Gt = 6,
     Gte = 7,
+    Rem = 8,
     // todo remaining ops
 }
 
@@ -39,6 +40,7 @@ impl From<u32> for Op {
             5 => Op::Div,
             6 => Op::Gt,
             7 => Op::Gte,
+            8 => Op::Rem,
             // todo add remaining ops
             _ => Op::Add,
         }

--- a/libtfhe-wrapper/src/api/ffi/api.rs
+++ b/libtfhe-wrapper/src/api/ffi/api.rs
@@ -33,6 +33,8 @@ pub enum Op {
     Ne = 13,
     Min = 14,
     Max = 15,
+    Shl = 16,
+    Shr = 17,
     // todo remaining ops
 }
 
@@ -55,6 +57,8 @@ impl From<u32> for Op {
             13 => Op::Ne,
             14 => Op::Min,
             15 => Op::Max,
+            16 => Op::Shl,
+            17 => Op::Shr,
             // todo add remaining ops
             _ => Op::Add,
         }

--- a/libtfhe-wrapper/src/api/ffi/api.rs
+++ b/libtfhe-wrapper/src/api/ffi/api.rs
@@ -26,6 +26,9 @@ pub enum Op {
     Gt = 6,
     Gte = 7,
     Rem = 8,
+    BitAnd = 9,
+    BitOr = 10,
+    BitXor = 11,
     // todo remaining ops
 }
 
@@ -41,6 +44,9 @@ impl From<u32> for Op {
             6 => Op::Gt,
             7 => Op::Gte,
             8 => Op::Rem,
+            9 => Op::BitAnd,
+            10 => Op::BitOr,
+            11 => Op::BitXor,
             // todo add remaining ops
             _ => Op::Add,
         }

--- a/libtfhe-wrapper/src/api/ffi/api.rs
+++ b/libtfhe-wrapper/src/api/ffi/api.rs
@@ -23,6 +23,8 @@ pub enum Op {
     Lt = 3,
     Lte = 4,
     Div = 5,
+    Gt = 6,
+    Gte = 7,
     // todo remaining ops
 }
 
@@ -35,6 +37,8 @@ impl From<u32> for Op {
             3 => Op::Lt,
             4 => Op::Lte,
             5 => Op::Div,
+            6 => Op::Gt,
+            7 => Op::Gte,
             // todo add remaining ops
             _ => Op::Add,
         }

--- a/libtfhe-wrapper/src/api/ffi/api.rs
+++ b/libtfhe-wrapper/src/api/ffi/api.rs
@@ -22,6 +22,8 @@ pub enum Op {
     Mul = 2,
     Lt = 3,
     Lte = 4,
+    Div = 5,
+    // todo remaining ops
 }
 
 impl From<u32> for Op {
@@ -32,6 +34,8 @@ impl From<u32> for Op {
             2 => Op::Mul,
             3 => Op::Lt,
             4 => Op::Lte,
+            5 => Op::Div,
+            // todo add remaining ops
             _ => Op::Add,
         }
     }

--- a/libtfhe-wrapper/src/api/ffi/api.rs
+++ b/libtfhe-wrapper/src/api/ffi/api.rs
@@ -31,6 +31,8 @@ pub enum Op {
     BitXor = 11,
     Eq = 12,
     Ne = 13,
+    Min = 14,
+    Max = 15,
     // todo remaining ops
 }
 
@@ -51,6 +53,8 @@ impl From<u32> for Op {
             11 => Op::BitXor,
             12 => Op::Eq,
             13 => Op::Ne,
+            14 => Op::Min,
+            15 => Op::Max,
             // todo add remaining ops
             _ => Op::Add,
         }

--- a/libtfhe-wrapper/src/api/ffi/api.rs
+++ b/libtfhe-wrapper/src/api/ffi/api.rs
@@ -29,6 +29,8 @@ pub enum Op {
     BitAnd = 9,
     BitOr = 10,
     BitXor = 11,
+    Eq = 12,
+    Ne = 13,
     // todo remaining ops
 }
 
@@ -47,6 +49,8 @@ impl From<u32> for Op {
             9 => Op::BitAnd,
             10 => Op::BitOr,
             11 => Op::BitXor,
+            12 => Op::Eq,
+            13 => Op::Ne,
             // todo add remaining ops
             _ => Op::Add,
         }

--- a/libtfhe-wrapper/src/math.rs
+++ b/libtfhe-wrapper/src/math.rs
@@ -2,7 +2,7 @@ use crate::api::Op;
 use crate::error::RustError;
 use crate::keys::GlobalKeys;
 use serde::Serialize;
-use std::ops::{Add, Mul, Sub};
+use std::ops::{Add, Mul, Sub, Div};
 use tfhe::prelude::FheOrd;
 use tfhe::prelude::*;
 
@@ -57,13 +57,13 @@ define_op_fn!(op_uint32, deserialize_fhe_uint32, FheUint32);
 ///
 /// An `UnmanagedVector` containing the serialized result.
 fn common_op<
-    T: Add<Output = T> + Sub<Output = T> + Mul<Output = T> + FheOrd<Output = T> + FheEq + Serialize,
+    T: Add<Output = T> + Sub<Output = T> + Mul<Output = T> + Div<Output = T> + FheOrd<Output = T> + FheEq + Serialize,
+    //todo verify added `Div`
 >(
     num1: T,
     num2: T,
     operation: Op,
 ) -> Result<Vec<u8>, RustError> {
-
     if !GlobalKeys::is_server_key_set() {
         return Err(RustError::generic_error("server key must be set for math operation"));
     }
@@ -75,6 +75,8 @@ fn common_op<
         Op::Mul => num1 * num2,
         Op::Lt => num1.lt(num2),
         Op::Lte => num1.le(num2),
+        Op::Div => num1 / num2,
+        // todo add remaining ops
     };
 
     bincode::serialize(&result).map_err(|err| {

--- a/libtfhe-wrapper/src/math.rs
+++ b/libtfhe-wrapper/src/math.rs
@@ -76,6 +76,8 @@ fn common_op<
         Op::Lt => num1.lt(num2),
         Op::Lte => num1.le(num2),
         Op::Div => num1 / num2,
+        Op::Gt => num1.gt(num2),
+        Op::Gte => num1.ge(num2),
         // todo add remaining ops
     };
 

--- a/libtfhe-wrapper/src/math.rs
+++ b/libtfhe-wrapper/src/math.rs
@@ -3,7 +3,6 @@ use crate::error::RustError;
 use crate::keys::GlobalKeys;
 use serde::Serialize;
 use std::ops::{Add, Mul, Sub, Div, Rem, BitOr, BitAnd, BitXor};
-use tfhe::prelude::FheOrd;
 use tfhe::prelude::*;
 
 use crate::serialization::{deserialize_fhe_uint16, deserialize_fhe_uint32, deserialize_fhe_uint8};
@@ -67,6 +66,8 @@ fn common_op<
     Rem<Output = T> +
     FheOrd<Output = T> +
     FheEq<Output = T> +
+    for <'a> FheMin<&'a T, Output = T> +
+    for <'a> FheMax<&'a T, Output = T> +
     Serialize,
     // todo add more (maybe)
 >(
@@ -94,6 +95,8 @@ fn common_op<
         Op::BitXor => num1 ^ num2,
         Op::Eq => num1.eq(num2),
         Op::Ne => num1.ne(num2),
+        Op::Min => num1.min(&num2),
+        Op::Max => num1.max(&num2),
         // todo add remaining ops
     };
 

--- a/libtfhe-wrapper/src/math.rs
+++ b/libtfhe-wrapper/src/math.rs
@@ -2,7 +2,7 @@ use crate::api::Op;
 use crate::error::RustError;
 use crate::keys::GlobalKeys;
 use serde::Serialize;
-use std::ops::{Add, Mul, Sub, Div, Rem};
+use std::ops::{Add, Mul, Sub, Div, Rem, BitOr, BitAnd, BitXor};
 use tfhe::prelude::FheOrd;
 use tfhe::prelude::*;
 
@@ -61,6 +61,9 @@ fn common_op<
     Sub<Output = T> +
     Mul<Output = T> +
     Div<Output = T> +
+    BitAnd<Output = T> +
+    BitOr<Output = T> +
+    BitXor<Output = T> +
     Rem<Output = T> +
     FheOrd<Output = T> +
     FheEq + Serialize,
@@ -85,6 +88,10 @@ fn common_op<
         Op::Gt => num1.gt(num2),
         Op::Gte => num1.ge(num2),
         Op::Rem => num1 % num2,
+        Op::BitAnd => num1 & num2,
+        Op::BitOr => num1 | num2,
+        Op::BitXor => num1 ^ num2,
+        _ => return Err(RustError::generic_error("operation code not recognized")),
         // todo add remaining ops
     };
 

--- a/libtfhe-wrapper/src/math.rs
+++ b/libtfhe-wrapper/src/math.rs
@@ -2,7 +2,7 @@ use crate::api::Op;
 use crate::error::RustError;
 use crate::keys::GlobalKeys;
 use serde::Serialize;
-use std::ops::{Add, Mul, Sub, Div};
+use std::ops::{Add, Mul, Sub, Div, Rem};
 use tfhe::prelude::FheOrd;
 use tfhe::prelude::*;
 
@@ -57,8 +57,14 @@ define_op_fn!(op_uint32, deserialize_fhe_uint32, FheUint32);
 ///
 /// An `UnmanagedVector` containing the serialized result.
 fn common_op<
-    T: Add<Output = T> + Sub<Output = T> + Mul<Output = T> + Div<Output = T> + FheOrd<Output = T> + FheEq + Serialize,
-    //todo verify added `Div`
+    T: Add<Output = T> +
+    Sub<Output = T> +
+    Mul<Output = T> +
+    Div<Output = T> +
+    Rem<Output = T> +
+    FheOrd<Output = T> +
+    FheEq + Serialize,
+    // todo add more (maybe)
 >(
     num1: T,
     num2: T,
@@ -78,6 +84,7 @@ fn common_op<
         Op::Div => num1 / num2,
         Op::Gt => num1.gt(num2),
         Op::Gte => num1.ge(num2),
+        Op::Rem => num1 % num2,
         // todo add remaining ops
     };
 

--- a/libtfhe-wrapper/src/math.rs
+++ b/libtfhe-wrapper/src/math.rs
@@ -66,7 +66,8 @@ fn common_op<
     BitXor<Output = T> +
     Rem<Output = T> +
     FheOrd<Output = T> +
-    FheEq + Serialize,
+    FheEq<Output = T> +
+    Serialize,
     // todo add more (maybe)
 >(
     num1: T,
@@ -91,7 +92,8 @@ fn common_op<
         Op::BitAnd => num1 & num2,
         Op::BitOr => num1 | num2,
         Op::BitXor => num1 ^ num2,
-        _ => return Err(RustError::generic_error("operation code not recognized")),
+        Op::Eq => num1.eq(num2),
+        Op::Ne => num1.ne(num2),
         // todo add remaining ops
     };
 

--- a/libtfhe-wrapper/src/math.rs
+++ b/libtfhe-wrapper/src/math.rs
@@ -2,7 +2,7 @@ use crate::api::Op;
 use crate::error::RustError;
 use crate::keys::GlobalKeys;
 use serde::Serialize;
-use std::ops::{Add, Mul, Sub, Div, Rem, BitOr, BitAnd, BitXor};
+use std::ops::{Add, Mul, Sub, Div, Rem, BitOr, BitAnd, BitXor, Shl, Shr};
 use tfhe::prelude::*;
 
 use crate::serialization::{deserialize_fhe_uint16, deserialize_fhe_uint32, deserialize_fhe_uint8};
@@ -68,6 +68,8 @@ fn common_op<
     FheEq<Output = T> +
     for <'a> FheMin<&'a T, Output = T> +
     for <'a> FheMax<&'a T, Output = T> +
+    Shl<Output = T> +
+    Shr<Output = T> +
     Serialize,
     // todo add more (maybe)
 >(
@@ -97,6 +99,8 @@ fn common_op<
         Op::Ne => num1.ne(num2),
         Op::Min => num1.min(&num2),
         Op::Max => num1.max(&num2),
+        Op::Shl => num1 << num2,
+        Op::Shr => num1 >> num2,
         // todo add remaining ops
     };
 


### PR DESCRIPTION
Added operations + tests of:
Div
Gt
Gte
Rem (remainder)
Shl (shift left)
Shr (shift right)
Max
Min
Eq
Ne
And
Xor
Or

On another branch: Not - since it's unary so it required a new abi


The only others that are left that I've seen are:
* Neg (negation - minus) - Itzik said it's not relevant for now. Also we are currently working with unsigned numbers...
* Operators + assignment (+=, -=, *=, /=), but these are more syntactic sugar for languages with operator overloading, in Go it would not make it much easier to work with as there's no operator overloading. If we want we can later add these without touching the rust side, just using the already existing non-assignment versions in go, so you can do `a.AddAssign(b)` in addition to the existing `a = a.Add(b)`
* Ternary Operator