### PR TITLE
Seal output

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ You can build it using `make build-go`. I recently improved the interface, so a 
 - `LoadPublicKey([]byte) (bool, error)`: Loads a public key
 - `LoadServerKey([]byte) (bool, error)`: Loads a server key
 - `Decrypt(Ciphertext) (uint64, error)`: Decrypts a ciphertext
+- `SealOutput(Ciphertext, []byte)`: Seals the decrypted value of a ciphertext to a specific user's public key
 - `PublicKey() ([]byte, error)`: Retrieves the public key
 - `CheckRequire(*Ciphertext) (bool, error)`: Checks a requirement via the oracle
 - `StoreRequire(*Ciphertext, uint64) (bool, error)`: Stores a requirement into the oracle
@@ -71,6 +72,34 @@ Ciphertext API List
 - `Mul(*Ciphertext) (*Ciphertext, error)`: Performs ciphertext multiplication.
 
 - `Lt(*Ciphertext) (*Ciphertext, error)`: Performs less than comparison between ciphertexts.
+
+- `Lte(*Ciphertext) (*Ciphertext, error)`: Performs less than or equal comparison between ciphertexts.
+
+- `Div(*Ciphertext) (*Ciphertext, error)`: Performs ciphertext division.
+
+- `Gt(*Ciphertext) (*Ciphertext, error)`: Performs greater than comparison between ciphertexts.
+
+- `Gte(*Ciphertext) (*Ciphertext, error)`: Performs greater than or equal comparison between ciphertexts.
+
+- `And(*Ciphertext) (*Ciphertext, error)`: Performs ciphertext bitwise And operation.
+
+- `Or(*Ciphertext) (*Ciphertext, error)`: Performs ciphertext bitwise Or operation.
+
+- `Xor(*Ciphertext) (*Ciphertext, error)`: Performs ciphertext bitwise Xor operation.
+
+- `Eq(*Ciphertext) (*Ciphertext, error)`: Performs equality comparison between ciphertexts.
+
+- `Ne(*Ciphertext) (*Ciphertext, error)`: Performs inequality comparison between ciphertexts.
+
+- `Min(*Ciphertext) (*Ciphertext, error)`: Returns the smaller of the two ciphertexts.
+
+- `Max(*Ciphertext) (*Ciphertext, error)`: Returns the bigger of the two ciphertexts.
+
+- `Shl(*Ciphertext) (*Ciphertext, error)`: Performs bitwise Shift-left operation.
+
+- `Shr(*Ciphertext) (*Ciphertext, error)`: Performs bitwise Shift-right operation.
+
+- `Not() (*Ciphertext, error)`: Performs bitwise Not operation.
 
 #### Encryption & Decryption
 

--- a/internal/api/amd64/lib.go
+++ b/internal/api/amd64/lib.go
@@ -199,7 +199,6 @@ func ExpandCompressedValue(cipherText []byte, intType UintType) ([]byte, error) 
 	}
 
 	return copyAndDestroyUnmanagedVector(res), nil
-
 }
 
 func Decrypt(cipherText []byte, intType UintType) (uint64, error) {

--- a/internal/oracle/decryption_network_amd64.go
+++ b/internal/oracle/decryption_network_amd64.go
@@ -81,49 +81,26 @@ func (oracle DecryptionOracle) Decrypt(ct *api.Ciphertext) (string, error) {
 	return msg.Value, nil
 }
 
-// todo (eshel) add pubkey
-func (oracle DecryptionOracle) Reencrypt(ct *api.Ciphertext, pubKey []byte) (string, error) {
-	ciphertext := ct.Serialization
-	key := decryptKey(ciphertext)
-
-	// todo (eshel): probably don't check with cache
-	data, err := oracle.db.Get([]byte(key))
+func (oracle DecryptionOracle) SealOutput(ct *api.Ciphertext, pubKey []byte) (string, error) {
+	// todo: maybe cache something here
+	// todo: NOTE that this is how we should call the decryption network, but it doesn't work yet over there
+	reencrypted, signature, err := (*oracle.client).Reencrypt(
+		&pb.FheEncrypted{
+			Data: ct.Serialization,
+			Type: pb.EncryptedType(ct.UintType),
+		},
+		hex.EncodeToString(pubKey),
+	)
 	if err != nil {
-		if errors.Is(err, memorydb.ErrMemorydbNotFound) {
-			// Key does not exist in local db; try checking via decryption network
-			reencrypted, signature, err := (*oracle.client).Reencrypt(
-				&pb.FheEncrypted{
-					Data: ct.Serialization,
-					Type: pb.EncryptedType(ct.UintType),
-				},
-				// todo (eshel) convert to string:
-				hex.EncodeToString(pubKey),
-			)
-			if err != nil {
-				return "", fmt.Errorf("could not reencrypt: %v", err)
-			}
-
-			fmt.Printf("Reencrypted: %v\n", reencrypted)
-			fmt.Printf("Signature: %s\n", signature)
-
-			// todo (eshel): verify signature
-			// todo (eshel): reencrypt
-
-			// todo (eshel): verify that we should not store the result in local cache before returning
-			return reencrypted, nil
-		}
-
-		// Some other error occurred
-		return "", err
+		return "", fmt.Errorf("could not reencrypt: %v", err)
 	}
 
-	// todo (eshel): probably remove cache match processing, as these values should not be cached
-	msg := dbDecryptMessage{}
-	if err := json.Unmarshal(data, &msg); err != nil {
-		// failed to validate signature
-		return "", fmt.Errorf("failed to unmarshal require signature")
-	}
-	return msg.Value, nil
+	fmt.Printf("Reencrypted: %v\n", reencrypted)
+	fmt.Printf("Signature: %s\n", signature)
+
+	// todo: verify signature
+
+	return reencrypted, nil
 }
 
 func (oracle DecryptionOracle) GetRequire(ct *api.Ciphertext) (bool, error) {

--- a/internal/oracle/decryption_network_amd64.go
+++ b/internal/oracle/decryption_network_amd64.go
@@ -81,7 +81,6 @@ func (oracle DecryptionOracle) Decrypt(ct *api.Ciphertext) (string, error) {
 }
 
 func (oracle DecryptionOracle) GetRequire(ct *api.Ciphertext) (bool, error) {
-
 	ciphertext := ct.Serialization
 	key := requireKey(ciphertext)
 

--- a/internal/oracle/http_oracle.go
+++ b/internal/oracle/http_oracle.go
@@ -110,3 +110,8 @@ func (HttpOracle) Decrypt(ciphertext *api.Ciphertext) (string, error) {
 	panic("Not implemented yet :(")
 	// return "", nil
 }
+
+func (HttpOracle) Reencrypt(ciphertext *api.Ciphertext, pubKey []byte) (string, error) {
+	panic("Not implemented yet :(")
+	// return "", nil
+}

--- a/internal/oracle/http_oracle.go
+++ b/internal/oracle/http_oracle.go
@@ -111,7 +111,7 @@ func (HttpOracle) Decrypt(ciphertext *api.Ciphertext) (string, error) {
 	// return "", nil
 }
 
-func (HttpOracle) Reencrypt(ciphertext *api.Ciphertext, pubKey []byte) (string, error) {
+func (HttpOracle) SealOutput(ciphertext *api.Ciphertext, pubKey []byte) (string, error) {
 	panic("Not implemented yet :(")
 	// return "", nil
 }

--- a/internal/oracle/local_oracle.go
+++ b/internal/oracle/local_oracle.go
@@ -11,7 +11,6 @@ import (
 	"github.com/fhenixprotocol/go-tfhe/internal/oracle/memorydb"
 	"golang.org/x/crypto/nacl/box"
 	"math/big"
-	"os"
 	"strconv"
 )
 
@@ -80,12 +79,6 @@ func encryptForUser(value *big.Int, userPublicKey []byte) ([]byte, error) {
 
 func encryptToUserKey(value *big.Int, pubKey []byte) ([]byte, error) {
 	ct, err := encryptForUser(value, pubKey)
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO: for testing
-	err = os.WriteFile("/tmp/public_encrypt_result", ct, 0o644)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/oracle/local_oracle.go
+++ b/internal/oracle/local_oracle.go
@@ -1,11 +1,16 @@
 package oracle
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/fhenixprotocol/go-tfhe/internal/api"
 	"github.com/fhenixprotocol/go-tfhe/internal/oracle/memorydb"
+	"golang.org/x/crypto/nacl/box"
+	"math/big"
+	"os"
 	"strconv"
 )
 
@@ -35,6 +40,46 @@ func (o MemoryDb) Decrypt(ct *api.Ciphertext) (string, error) {
 	}
 
 	return resultAsString, nil
+}
+
+func classicalPublicKeyEncrypt(value *big.Int, userPublicKey []byte) ([]byte, error) {
+	encrypted, err := box.SealAnonymous(nil, value.Bytes(), (*[32]byte)(userPublicKey), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	return encrypted, nil
+}
+
+func encryptToUserKey(value *big.Int, pubKey []byte) ([]byte, error) {
+	ct, err := classicalPublicKeyEncrypt(value, pubKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: for testing
+	err = os.WriteFile("/tmp/public_encrypt_result", ct, 0o644)
+	if err != nil {
+		return nil, err
+	}
+
+	return ct, nil
+}
+
+// todo (eshel) document and implement
+// todo (eshel) return value should be bytes or ct?
+func (o MemoryDb) Reencrypt(ct *api.Ciphertext, pubKey []byte) (string, error) {
+	result, err := ct.Decrypt()
+	if err != nil {
+		return "", err
+	}
+
+	// todo (eshel) encrypt again
+	reencrypted, err := encryptToUserKey(result, pubKey)
+
+	// todo (eshel) should we cache something here?
+	reencryptedAsString := hex.EncodeToString(reencrypted)
+
+	return reencryptedAsString, nil
 }
 
 func (o MemoryDb) PutRequire(ct *api.Ciphertext, decryptedNotZero bool) error {

--- a/internal/oracle/local_oracle.go
+++ b/internal/oracle/local_oracle.go
@@ -93,21 +93,18 @@ func encryptToUserKey(value *big.Int, pubKey []byte) ([]byte, error) {
 	return ct, nil
 }
 
-// todo (eshel) document and implement
-// todo (eshel) return value should be bytes or ct?
-func (o MemoryDb) Reencrypt(ct *api.Ciphertext, pubKey []byte) (string, error) {
+func (o MemoryDb) SealOutput(ct *api.Ciphertext, pubKey []byte) (string, error) {
 	result, err := ct.Decrypt()
 	if err != nil {
 		return "", err
 	}
 
-	// todo (eshel) encrypt again
-	reencrypted, err := encryptToUserKey(result, pubKey)
+	sealedResult, err := encryptToUserKey(result, pubKey)
 
 	// todo (eshel) should we cache something here?
-	reencryptedAsString := hex.EncodeToString(reencrypted)
+	sealedAsString := hex.EncodeToString(sealedResult)
 
-	return reencryptedAsString, nil
+	return sealedAsString, nil
 }
 
 func (o MemoryDb) PutRequire(ct *api.Ciphertext, decryptedNotZero bool) error {

--- a/internal/oracle/oracle.go
+++ b/internal/oracle/oracle.go
@@ -28,7 +28,7 @@ func decryptKey(ciphertext []byte) string {
 type Oracle interface {
 	GetRequire(ct *api.Ciphertext) (bool, error)
 	Decrypt(ct *api.Ciphertext) (string, error)
-	Reencrypt(ct *api.Ciphertext, pubKey []byte) (string, error)
+	SealOutput(ct *api.Ciphertext, pubKey []byte) (string, error)
 	PutRequire(ct *api.Ciphertext, decryptedNotZero bool) error
 	Close()
 }

--- a/internal/oracle/oracle.go
+++ b/internal/oracle/oracle.go
@@ -28,6 +28,7 @@ func decryptKey(ciphertext []byte) string {
 type Oracle interface {
 	GetRequire(ct *api.Ciphertext) (bool, error)
 	Decrypt(ct *api.Ciphertext) (string, error)
+	Reencrypt(ct *api.Ciphertext, pubKey []byte) (string, error)
 	PutRequire(ct *api.Ciphertext, decryptedNotZero bool) error
 	Close()
 }

--- a/lib.go
+++ b/lib.go
@@ -72,7 +72,6 @@ func SealOutput(ciphertext Ciphertext, pubKey []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	// todo: verify that this is the correct conversion from string to bytes
 	return hex.DecodeString(result)
 }
 

--- a/lib.go
+++ b/lib.go
@@ -2,6 +2,7 @@ package tfhe
 
 import (
 	"crypto/ed25519"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -57,6 +58,22 @@ func Decrypt(ciphertext Ciphertext) (uint64, error) {
 	//}
 	//
 	//return result, nil
+}
+
+// Reencrypt decrypts the given Ciphertext and then encrypts it back to the given public key.
+// It checks if the keys are initialized before performing decryption
+func Reencrypt(ciphertext Ciphertext, pubKey []byte) ([]byte, error) {
+	if len(ciphertext.Serialization) == 0 {
+		return nil, fmt.Errorf("cannot check require without encrypted bytes")
+	}
+
+	result, err := oracleStorage.Reencrypt(&ciphertext, pubKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// todo: verify that this is the correct conversion from string to bytes
+	return hex.DecodeString(result)
 }
 
 // PublicKey retrieves the current public key

--- a/lib.go
+++ b/lib.go
@@ -60,14 +60,14 @@ func Decrypt(ciphertext Ciphertext) (uint64, error) {
 	//return result, nil
 }
 
-// Reencrypt decrypts the given Ciphertext and then encrypts it back to the given public key.
+// SealOutput encrypts the given Ciphertext to the given public key.
 // It checks if the keys are initialized before performing decryption
-func Reencrypt(ciphertext Ciphertext, pubKey []byte) ([]byte, error) {
+func SealOutput(ciphertext Ciphertext, pubKey []byte) ([]byte, error) {
 	if len(ciphertext.Serialization) == 0 {
 		return nil, fmt.Errorf("cannot check require without encrypted bytes")
 	}
 
-	result, err := oracleStorage.Reencrypt(&ciphertext, pubKey)
+	result, err := oracleStorage.SealOutput(&ciphertext, pubKey)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
now calls oracle's `reencrypt` (which still does not work as it is not implemented correctly in oracle, the format changed to return a struct that conforms to metamask, that is still a todo).
Also, renamed Reencrypt to SealOutput at the levels that are facing outwards (still calls the decryption's oracle as `reencrypt` as I didn't want to change the protobuf)

fheos: https://github.com/FhenixProtocol/fheos/pull/44
monday: https://fhenix.monday.com/boards/1216577959/views/4451803/pulses/1334919281