### PR TITLE
panic around rust math ops

### DIFF
--- a/internal/api/tfheCipherText.go
+++ b/internal/api/tfheCipherText.go
@@ -181,8 +181,8 @@ func (ct *Ciphertext) Cast(toType UintType) (*Ciphertext, error) {
 }
 
 func (ct *Ciphertext) Cmux(ifTrue *Ciphertext, ifFalse *Ciphertext) (*Ciphertext, error) {
-	if (ifFalse.UintType != ifTrue.UintType) || (ct.UintType != ifTrue.UintType) {
-		return nil, fmt.Errorf("cannot use selector on uints / control of different types")
+	if ifFalse.UintType != ifTrue.UintType {
+		return nil, fmt.Errorf("cannot use selector on uints of different types")
 	}
 
 	res, err := cmux(ct.Serialization, ifTrue.Serialization, ifFalse.Serialization, uint8(ct.UintType))

--- a/libtfhe-wrapper/src/api/ffi/api.rs
+++ b/libtfhe-wrapper/src/api/ffi/api.rs
@@ -224,9 +224,7 @@ pub fn math_operation_helper(
     match result {
         Ok(Ok(x)) => Ok(x),
         Ok(Err(e)) => Err(e),
-        // Err(e) => Err(RustError::math_panic(format!("panic in math operation: {}", e.to_string()))),
-        // todo (eshel): retrieve error message
-        Err(_) => Err(RustError::math_panic("")),
+        Err(e) => Err(RustError::math_panic(format!("panic in math operation: {:#?}", e.downcast_ref::<&str>()))),
     }
 }
 
@@ -286,10 +284,7 @@ pub unsafe extern "C" fn unary_math_operation(
     let result = match result_may_panic {
         Ok(Ok(x)) => Ok(x),
         Ok(Err(e)) => Err(e),
-        // Err(e) => Err(RustError::math_panic(format!("panic in math operation: {}", e.to_string()))),
-        // todo (eshel): retrieve error message
-        // Err(_) => Err(RustError::math_panic(format!())),
-        Err(_) => Err(RustError::math_panic("")),
+        Err(e) => Err(RustError::math_panic(format!("panic in math operation: {:#?}", e.downcast_ref::<&str>()))),
     };
 
     let result = handle_c_error_binary(result, err_msg);

--- a/libtfhe-wrapper/src/api/ffi/api.rs
+++ b/libtfhe-wrapper/src/api/ffi/api.rs
@@ -13,6 +13,8 @@ use crate::math::{
     op_uint16, op_uint32, op_uint8, unary_op_uint16, unary_op_uint32, unary_op_uint8,
 };
 
+use std::panic::catch_unwind;
+
 #[cfg(target_arch = "wasm32")]
 use tfhe::{
     generate_keys, shortint::parameters::PARAM_MESSAGE_2_CARRY_2_COMPACT_PK as KEYGEN_PARAMS,
@@ -212,10 +214,18 @@ pub fn math_operation_helper(
     operation: Op,
     uint_type: FheUintType,
 ) -> Result<Vec<u8>, RustError> {
-    match uint_type {
-        FheUintType::Uint8 => op_uint8(lhs, rhs, operation),
-        FheUintType::Uint16 => op_uint16(lhs, rhs, operation),
-        FheUintType::Uint32 => op_uint32(lhs, rhs, operation),
+    let result = catch_unwind(|| {
+        match uint_type {
+            FheUintType::Uint8 => op_uint8(lhs, rhs, operation),
+            FheUintType::Uint16 => op_uint16(lhs, rhs, operation),
+            FheUintType::Uint32 => op_uint32(lhs, rhs, operation),
+        }
+    });
+
+    match result {
+        Ok(Ok(x)) => Ok(x),
+        Ok(Err(e)) => Err(e),
+        Err(e) => Err(RustError::math_panic(format!("panic in math operation: {}", e.to_string()))),
     }
 }
 
@@ -264,10 +274,18 @@ pub unsafe extern "C" fn unary_math_operation(
         }
     };
 
-    let result = match uint_type {
-        FheUintType::Uint8 => unary_op_uint8(lhs_slice, operation),
-        FheUintType::Uint16 => unary_op_uint16(lhs_slice, operation),
-        FheUintType::Uint32 => unary_op_uint32(lhs_slice, operation),
+    let result_may_panic = catch_unwind(|| {
+        match uint_type {
+            FheUintType::Uint8 => unary_op_uint8(lhs_slice, operation),
+            FheUintType::Uint16 => unary_op_uint16(lhs_slice, operation),
+            FheUintType::Uint32 => unary_op_uint32(lhs_slice, operation),
+        }
+    });
+
+    let result = match result_may_panic {
+        Ok(Ok(x)) => Ok(x),
+        Ok(Err(e)) => Err(e),
+        Err(e) => Err(RustError::math_panic(format!("panic in unary math operation: {}", e.to_string()))),
     };
 
     let result = handle_c_error_binary(result, err_msg);

--- a/libtfhe-wrapper/src/error.rs
+++ b/libtfhe-wrapper/src/error.rs
@@ -11,11 +11,24 @@ pub enum RustError {
         #[cfg(feature = "backtraces")]
         backtrace: Backtrace,
     },
+    MathPanic {
+        name: String,
+        #[cfg(feature = "backtraces")]
+        backtrace: Backtrace,
+    },
 }
 
 impl RustError {
     pub fn generic_error<T: Into<String>>(name: T) -> Self {
         RustError::GenericError {
+            name: name.into(),
+            #[cfg(feature = "backtraces")]
+            backtrace: Backtrace::capture(),
+        }
+    }
+
+    pub fn math_panic<T: Into<String>>(name: T) -> Self {
+        RustError::MathPanic {
             name: name.into(),
             #[cfg(feature = "backtraces")]
             backtrace: Backtrace::capture(),

--- a/libtfhe-wrapper/src/math.rs
+++ b/libtfhe-wrapper/src/math.rs
@@ -113,11 +113,7 @@ fn common_op<
         Op::Min => num1.min(&num2),
         Op::Max => num1.max(&num2),
         Op::Shl => num1 << num2,
-        Op::Shr => {
-            // todo (eshel): remove
-            assert!(false, "todo: testing panic");
-            num1 >> num2
-        },
+        Op::Shr => num1 >> num2
     };
 
     bincode::serialize(&result).map_err(|err| {

--- a/libtfhe-wrapper/src/math.rs
+++ b/libtfhe-wrapper/src/math.rs
@@ -28,16 +28,16 @@ macro_rules! define_op_fn {
         pub fn $func_name(lhs: &[u8], rhs: &[u8], operation: Op) -> Result<Vec<u8>, RustError> {
             match ($deserialize_func(lhs, false), $deserialize_func(rhs, false)) {
                 (Err(e), _) => {
-                    log::error!("faileddeserializing lhs value: {:?}", e);
+                    log::error!("failed deserializing lhs value: {:?}", e);
                     Err(RustError::generic_error(format!(
-                        "faileddeserializing lhs value: {:?}",
+                        "failed deserializing lhs value: {:?}",
                         e
                     )))
                 }
                 (_, Err(e)) => {
-                    log::error!("faileddeserializing rhs value: {:?}", e);
+                    log::error!("failed deserializing rhs value: {:?}", e);
                     Err(RustError::generic_error(format!(
-                        "faileddeserializing rhs value: {:?}",
+                        "failed deserializing rhs value: {:?}",
                         e
                     )))
                 }


### PR DESCRIPTION
We now can recover gracefully from panics inside math operations, instead of having the node crash completely.
This was tested by intentionally panic-ing: I saw it just prints the error.

Thoughts:
1) Maybe test further: what if the sequencer fails but other nodes don't?
2) The work around this change exposed the following behaviour, which may be a bit problematic:
Reverts that happen in `tx commit` mode will not raise an error in javascript clients, but fail silently. Then client will then need to check the tx status itself. Errors *will* raise if the revert occurs during the prior gas estimation phase of the tx. This does not solve the problem because a. clients can omit gas estimation by specifying gas limits, and b. certain cases do not raise errors even in gas estimations. Namely, if there's an error in a FHE math operation, then the proccessing of the tx on gas estimation mode will pass successfully, because on gas estimation we skip the math operations.

nitro: https://github.com/FhenixProtocol/nitro/pull/46
fheos: https://github.com/FhenixProtocol/go-tfhe/pull/27
monday: https://fhenix.monday.com/boards/1216577959/views/4451803/pulses/1352850881
