### PR TITLE
Catch all panics

### DIFF
--- a/libtfhe-wrapper/src/error.rs
+++ b/libtfhe-wrapper/src/error.rs
@@ -17,6 +17,36 @@ pub enum RustError {
         #[cfg(feature = "backtraces")]
         backtrace: Backtrace,
     },
+    #[error("Panic during cast operation: {}", name)]
+    CastPanic {
+        name: String,
+        #[cfg(feature = "backtraces")]
+        backtrace: Backtrace,
+    },
+    #[error("Panic during encrypt operation: {}", name)]
+    EncryptPanic {
+        name: String,
+        #[cfg(feature = "backtraces")]
+        backtrace: Backtrace,
+    },
+    #[error("Panic during decrypt operation: {}", name)]
+    DecryptPanic {
+        name: String,
+        #[cfg(feature = "backtraces")]
+        backtrace: Backtrace,
+    },
+    #[error("Panic during trivial encrypt operation: {}", name)]
+    TrivialEncryptPanic {
+        name: String,
+        #[cfg(feature = "backtraces")]
+        backtrace: Backtrace,
+    },
+    #[error("Panic during expand compressed operation: {}", name)]
+    ExpandPanic {
+        name: String,
+        #[cfg(feature = "backtraces")]
+        backtrace: Backtrace,
+    },
 }
 
 impl RustError {
@@ -30,6 +60,46 @@ impl RustError {
 
     pub fn math_panic<T: Into<String>>(name: T) -> Self {
         RustError::MathPanic {
+            name: name.into(),
+            #[cfg(feature = "backtraces")]
+            backtrace: Backtrace::capture(),
+        }
+    }
+
+    pub fn cast_panic<T: Into<String>>(name: T) -> Self {
+        RustError::CastPanic {
+            name: name.into(),
+            #[cfg(feature = "backtraces")]
+            backtrace: Backtrace::capture(),
+        }
+    }
+
+    pub fn encrypt_panic<T: Into<String>>(name: T) -> Self {
+        RustError::EncryptPanic {
+            name: name.into(),
+            #[cfg(feature = "backtraces")]
+            backtrace: Backtrace::capture(),
+        }
+    }
+
+    pub fn decrypt_panic<T: Into<String>>(name: T) -> Self {
+        RustError::DecryptPanic {
+            name: name.into(),
+            #[cfg(feature = "backtraces")]
+            backtrace: Backtrace::capture(),
+        }
+    }
+
+    pub fn trivial_encrypt_panic<T: Into<String>>(name: T) -> Self {
+        RustError::TrivialEncryptPanic {
+            name: name.into(),
+            #[cfg(feature = "backtraces")]
+            backtrace: Backtrace::capture(),
+        }
+    }
+
+    pub fn expand_compressed_panic<T: Into<String>>(name: T) -> Self {
+        RustError::ExpandPanic {
             name: name.into(),
             #[cfg(feature = "backtraces")]
             backtrace: Backtrace::capture(),


### PR DESCRIPTION
Panics in rust's fhe integers operations cause the node to crash.
For that reason we wrapped the math operations with a `catch` that catches panics.
There was a report that a panic still caused the node to crash, which happened where the `catch` mechanism was already allegedly in place. I tried to reproduce the issue In the specified versions, but I actually saw that the panic gets caught correctly. (This reported panic seemed to rise from a math operation, which we did wrap).
So there is still not definitive evidence that there are troublesome panics.
Nevertheless, In this PR I wrap other places that can produce panics, just in case.
Namely, I wrapped `encrypt`, `encrypt_trivial`, `decrypt`, `expand_compressed` and `cast` functions, all of which can panic.

fheos: https://github.com/FhenixProtocol/fheos/pull/65
nitro: https://github.com/FhenixProtocol/nitro/pull/60